### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,12 +97,11 @@ jobs:
           ls -lah release/
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
-        with:
-          files: release/*
-          draft: false
-          prerelease: false
-          generate_release_notes: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            release/* \
+            --title "${{ github.ref_name }}" \
+            --generate-notes


### PR DESCRIPTION
fix #14 and #10

@wkoszek release v0.0.1-alpha works: https://github.com/bsubio/cli/releases/tag/v0.0.1-alpha
To release we just need to push tags v0.0.1 then it will trigger the release.
I push tags v0.0.1-alpha on this alpha-release branch for test.