### PR TITLE
Feat: Add Homebrew tap support (fixes #38)

### DIFF
--- a/.claude/skills/workflow/SKILL.md
+++ b/.claude/skills/workflow/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: proper workflow
+description: Follows project workflow for GitHub tickets, issues and branch naming, as well as tags, and tying issue with PRs
+---
+
+# Project GitHub Workflow skill
+
+## Instructions
+
+This skill instructs how to properly create GitHub issues, branches and pull requests for the project.
+
+When asked to create the ticket, feed the issue title and the body to the following command:
+
+    gh issue create -b "<body>" --title "<title>"
+
+where:
+
+    <body>
+    <title>
+
+are body of the issue and title, respectively.
+
+When work on the project ticket, pull the GitHub issue with this CLI command:
+
+    gh issue list
+
+When asked to work on the issue, make an appropriate branch with the following command:
+
+    git checkout -b issue/<issue_number>
+    git push -u origin issue/<issue_number>
+
+When asked to make PR:
+
+    gh pr create --title "<title>" --body "<body>"
+
+there:
+
+    <title>
+
+is the "Feat: " or "Fix: " + explanation of what was done and "(Fixes: #issuenum)" added, and
+
+    <body>
+
+being explanation of what we made.
+

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -78,6 +78,11 @@ release:
 
     ### Installation
 
+    #### macOS (Homebrew)
+    ```bash
+    brew install bsubio/tap/bsubio
+    ```
+
     #### Windows (Chocolatey)
     ```powershell
     choco install bsubio
@@ -100,6 +105,26 @@ release:
     - [Documentation](https://docs.bsub.io)
   name_template: "{{.Tag}}"
 
+brews:
+  - name: bsubio
+    ids:
+      - default
+    repository:
+      owner: bsubio
+      name: homebrew-tap
+      token: "{{ .Env.GITHUB_TOKEN }}"
+    commit_author:
+      name: bsub.io
+      email: contact@bsub.io
+    homepage: https://bsub.io
+    description: CLI for easy running heavy duty compute jobs in the cloud
+    license: MIT
+    skip_upload: false
+    install: |
+      bin.install "bsubio"
+    test: |
+      system "#{bin}/bsubio", "version"
+
 chocolateys:
   - name: bsubio
     ids:
@@ -121,7 +146,7 @@ chocolateys:
       bsubio CLI is a command-line tool for running heavy duty batch compute jobs and workflows on the bsubio cloud platform.
 
       Features:
-      - Submit and manage CPU/GPU batch jobs 
+      - Submit and manage CPU/GPU batch jobs
       - Monitor job status and logs
       - Manage job types and configurations
       - Upload and manage job artifacts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,3 +56,5 @@ Keep reviews short and concise.
 # Last words
 
 Feedback phrase like Rob Pike and Ken Thompson.
+
+Don't add any "Generated with" or "Co-Authored-By" to git commits.


### PR DESCRIPTION
Added brews configuration to .goreleaser.yaml to enable Homebrew tap distribution.

When released, bsubio will be installable via:
```bash
brew install bsubio/tap/bsubio
```

Changes:
- Added brews section to .goreleaser.yaml targeting bsubio/homebrew-tap
- Updated release footer with Homebrew installation instructions
- Configuration validated with goreleaser check

Fixes #38