### PR TITLE
Fix: Remove unused release_win job (fixes #76)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,33 +153,3 @@ jobs:
           NEW_VERSION="${{ steps.next_version.outputs.new_version }}"
           echo "✅ Release $NEW_VERSION created successfully!"
           echo "🔗 https://github.com/${{ github.repository }}/releases/tag/$NEW_VERSION"
-
-  release_win:
-    runs-on: windows-latest
-    needs: release
-    if: needs.release.outputs.should_release == 'true'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.25'
-
-      - name: Run GoReleaser for Chocolatey
-        uses: goreleaser/goreleaser-action@v6
-        with:
-          distribution: goreleaser
-          version: ~> v2
-          args: release --clean
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
-
-      - name: Chocolatey release summary
-        run: |
-          echo "✅ Chocolatey package published!"
-        shell: powershell


### PR DESCRIPTION
Removed the `release_win` job from `.github/workflows/release.yml` that is no longer needed.

This job was originally added to handle Chocolatey releases on a Windows runner. Since Chocolatey support is currently commented out in `.goreleaser.yaml`, this job:
- Unnecessarily runs on Windows runner (additional cost)
- Duplicates the main release job
- Serves no purpose

**Benefits of removal:**
- Reduced CI/CD runtime
- Lower GitHub Actions costs (no Windows runner)
- Simplified release workflow
- Easier to maintain

**Changes:**
- Removed lines 157-186 from `.github/workflows/release.yml`
- Removed entire `release_win` job block

Fixes #76