### PR TITLE
Fix: Use TAP_GITHUB_TOKEN for homebrew-tap access (fixes #79)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,6 +145,7 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
           CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
 
       - name: Release summary

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -174,7 +174,7 @@ homebrew_casks:
     repository:
       owner: bsubio
       name: homebrew-tap
-      token: "{{ .Env.GITHUB_TOKEN }}"
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
       branch: main
     commit_author:
       name: bsub.io


### PR DESCRIPTION
Fixed the 403 permission error when GoReleaser tries to push Homebrew cask formulas to bsubio/homebrew-tap.

**Problem:**
The default `GITHUB_TOKEN` provided by GitHub Actions doesn't have permission to push to other repositories in the organization. GoReleaser was failing with:
```
PUT https://api.github.com/repos/bsubio/homebrew-tap/contents/Casks/bsubio.rb: 403 Resource not accessible by integration
```

**Solution:**
Use a separate Personal Access Token (PAT) with `repo` scope for pushing to the homebrew-tap repository.

**Changes:**
- Updated `.goreleaser.yaml` to use `TAP_GITHUB_TOKEN` environment variable instead of `GITHUB_TOKEN` for the homebrew_casks repository token
- Updated `.github/workflows/release.yml` to pass `TAP_GITHUB_TOKEN` from secrets to GoReleaser

**Required setup before merging:**
1. Create a Personal Access Token with `repo` scope (or fine-grained PAT with `contents: write` for homebrew-tap)
2. Add the token as a repository secret named `TAP_GITHUB_TOKEN` in the cli repository settings

Once the secret is configured, GoReleaser will be able to successfully push cask formulas to the tap.

Fixes #79