### PR TITLE
Fix: Add xattr hook to remove macOS quarantine (fixes #81)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -187,6 +187,12 @@ homebrew_casks:
     url:
       template: "https://github.com/bsubio/cli/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
       verified: "github.com/bsubio/cli/"
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/bsubio"]
+          end
 
 # Announce releases (optional - uncomment if needed)
 # announce:


### PR DESCRIPTION
Fixed macOS Gatekeeper blocking the bsubio binary by adding a post-install hook to the Homebrew cask.

**Problem:**
macOS users couldn't run bsubio due to Gatekeeper blocking unsigned binaries:
```
"bsubio" Not Opened

Apple could not verify "bsubio" is free of malware that may harm your Mac or compromise your privacy.
```

**Solution:**
Added a post-install hook that automatically removes the quarantine attribute when installed via Homebrew.

**Changes:**
- Added `hooks.post.install` to `homebrew_casks` configuration in `.goreleaser.yaml`
- Executes `xattr -dr com.apple.quarantine` on the binary after installation
- Only runs on macOS (protected by `if OS.mac?` conditional)

**How it works:**
1. User runs `brew install bsubio/tap/bsubio`
2. Homebrew downloads and stages the binary
3. Post-install hook removes quarantine attribute
4. Binary runs without Gatekeeper blocking

**Note:**
This is a **temporary workaround**. Proper code signing and notarization (requires Apple Developer Program enrollment) should be implemented for production distribution.

Validated with `goreleaser check`.

Fixes #81