### PR TITLE
Fix: Correct GPG keyring path in Dockerfile.ci (fixes #99)

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y \
 
 # Add Mono repository and install Mono + .NET
 RUN gpg --homedir /tmp --no-default-keyring \
-    --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg \
+    --keyring /tmp/mono-keyring.gpg \
     --keyserver hkp://keyserver.ubuntu.com:80 \
     --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
     gpg --homedir /tmp --no-default-keyring \


### PR DESCRIPTION
## Summary
Fix GPG keyring path inconsistency in Dockerfile.ci that caused Docker build failures.

## Problem
The first `gpg --recv-keys` command was writing to `/usr/share/keyrings/mono-official-archive-keyring.gpg` but the second command was trying to export from `/tmp/mono-keyring.gpg`, causing the export to fail.

## Solution
Use `/tmp/mono-keyring.gpg` consistently in both GPG commands:
1. Receive keys into `/tmp/mono-keyring.gpg`
2. Export from `/tmp/mono-keyring.gpg` to final destination

## Test plan
- [x] Fix applied to Dockerfile.ci
- [ ] Docker build workflow completes successfully
- [ ] Mono and .NET packages installed correctly

Fixes #99