### PR TITLE
Fix: Add packages read permission to CI workflow (fixes #105)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- Add `packages: read` permission to CI workflow

## Problem
CI workflow was failing to pull Docker image from GHCR:
```
Error response from daemon: denied
```

## Solution
The workflow only had `contents: read` permission. Added `packages: read` to allow pulling from GitHub Container Registry.

## Test plan
- [ ] Verify CI workflow can pull Docker image successfully
- [ ] Confirm build completes without authentication errors