### PR TITLE
Feat: Add debugging output to CI workflow (fixes #109)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,26 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Debug environment
+        run: |
+          echo "=== GitHub Context ==="
+          echo "github.workspace: ${{ github.workspace }}"
+          echo "github.repository: ${{ github.repository }}"
+          echo "github.actor: ${{ github.actor }}"
+          echo ""
+          echo "=== Environment ==="
+          echo "PWD: $(pwd)"
+          echo "HOME: $HOME"
+          echo "USER: $(whoami)"
+          echo "UID: $(id -u)"
+          echo "GID: $(id -g)"
+          echo ""
+          echo "=== Workspace ownership ==="
+          ls -la $(pwd)
+          echo ""
+          echo "=== Git config before fix ==="
+          git config --global --list | grep safe.directory || echo "No safe.directory configured"
+
       - name: Fix Git ownership
         run: git config --global --add safe.directory /__w/cli/cli
 


### PR DESCRIPTION
## Summary
- Add debug step to show GitHub context and environment details
- Display workspace ownership and Git configuration
- Help diagnose container and path issues

## What's shown
- **GitHub context**: `github.workspace`, `github.repository`, `github.actor`
- **Environment**: PWD, HOME, USER, UID, GID
- **Workspace ownership**: `ls -la` output
- **Git config**: Current safe.directory settings

## Test plan
- [ ] Run CI and verify debug output appears
- [ ] Check that `github.workspace` value is visible
- [ ] Confirm workspace ownership shows correctly