### PR TITLE
Fix: Add packages read permission to release workflow (fixes #111)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: read
 
 jobs:
   release:


### PR DESCRIPTION
Adds `packages: read` permission to release.yml workflow.

The release workflow was failing to pull the Docker container image from GHCR because it lacked the necessary permission. The CI workflow already has this permission.

Fixes #111