### PR TITLE
fix: correct argument order in submit command help

### DIFF
--- a/cmd/bsubio/main.go
+++ b/cmd/bsubio/main.go
@@ -70,7 +70,7 @@ USAGE:
 COMMANDS:
     register                    Register with bsub.io using GitHub
     config                      Configure API key manually
-    submit [-o <file>] [-w] <input_file> <type>
+    submit [-o <file>] [-w] <type> <input_file>
                                 Submit a job for processing
     wait [-v] [-t <seconds>] <jobid>
                                 Wait for a job to complete


### PR DESCRIPTION
I forget the order then I look at the usage help but the order is wrong.

```
 submit [-o <file>] [-w] <input_file> <type>
```

I tried not work:
```
✗ ./bin/bsubio submit -w -o extracted.txt tests/data/essay.pdf pdf/extract
Error: input file not found: pdf/extract
```
where it should:
```
✗ ./bin/bsubio submit -w -o extracted.txt pdf/extract tests/data/essay.pdf
Submitting job for tests/data/essay.pdf...
```