### PR TITLE
Feat: Add job type validation to submit command (fixes #125)

### DIFF
--- a/cmd/bsubio/submit.go
+++ b/cmd/bsubio/submit.go
@@ -4,9 +4,109 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/bsubio/bsubio-go"
 )
+
+func getAvailableTypes(client *bsubio.BsubClient) ([]string, error) {
+	ctx := getContext()
+	resp, err := client.GetTypesWithResponse(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get job types: %w", err)
+	}
+
+	if resp.StatusCode() != 200 {
+		return nil, fmt.Errorf("failed to get job types: HTTP %d", resp.StatusCode())
+	}
+
+	if resp.JSON200 == nil || resp.JSON200.Types == nil {
+		return nil, fmt.Errorf("unexpected response format")
+	}
+
+	types := make([]string, 0, len(*resp.JSON200.Types))
+	for _, jobType := range *resp.JSON200.Types {
+		if jobType.Type != nil {
+			types = append(types, *jobType.Type)
+		}
+	}
+	return types, nil
+}
+
+func levenshteinDistance(s1, s2 string) int {
+	if len(s1) == 0 {
+		return len(s2)
+	}
+	if len(s2) == 0 {
+		return len(s1)
+	}
+
+	prev := make([]int, len(s2)+1)
+	curr := make([]int, len(s2)+1)
+
+	for j := 0; j <= len(s2); j++ {
+		prev[j] = j
+	}
+
+	for i := 1; i <= len(s1); i++ {
+		curr[0] = i
+		for j := 1; j <= len(s2); j++ {
+			cost := 1
+			if s1[i-1] == s2[j-1] {
+				cost = 0
+			}
+			curr[j] = min(
+				curr[j-1]+1,
+				min(prev[j]+1, prev[j-1]+cost),
+			)
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(s2)]
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func findClosestType(jobType string, availableTypes []string) string {
+	if len(availableTypes) == 0 {
+		return ""
+	}
+
+	minDistance := levenshteinDistance(jobType, availableTypes[0])
+	closest := availableTypes[0]
+
+	for _, t := range availableTypes[1:] {
+		distance := levenshteinDistance(jobType, t)
+		if distance < minDistance {
+			minDistance = distance
+			closest = t
+		}
+	}
+	return closest
+}
+
+func validateJobType(jobType string, availableTypes []string) error {
+	for _, t := range availableTypes {
+		if t == jobType {
+			return nil
+		}
+	}
+
+	suggestion := findClosestType(jobType, availableTypes)
+	var typesMsg strings.Builder
+	typesMsg.WriteString(fmt.Sprintf("invalid job type: %s\n\n", jobType))
+	typesMsg.WriteString(fmt.Sprintf("Did you mean: %s\n\n", suggestion))
+	typesMsg.WriteString("Available types:\n")
+	for _, t := range availableTypes {
+		typesMsg.WriteString(fmt.Sprintf("  - %s\n", t))
+	}
+	return fmt.Errorf("%s", typesMsg.String())
+}
 
 func runSubmit(args []string) error {
 	fs := flag.NewFlagSet("submit", flag.ContinueOnError)
@@ -62,6 +162,16 @@ func runSubmit(args []string) error {
 	// Create client
 	client, err := createClient()
 	if err != nil {
+		return err
+	}
+
+	// Validate job type
+	availableTypes, err := getAvailableTypes(client)
+	if err != nil {
+		return err
+	}
+
+	if err := validateJobType(jobType, availableTypes); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Summary
Add validation to verify job types against server's available types before submission. When an invalid type is provided, suggests the closest match using Levenshtein distance.

## Changes
- `getAvailableTypes()` - Fetches available types from server
- `validateJobType()` - Validates type and provides helpful error with suggestion
- `levenshteinDistance()` - Computes edit distance for fuzzy matching
- `findClosestType()` - Finds best match from available types
- Integrated validation into submit command flow

## Example
When using `convert/pdf` instead of `convert/markdown/pdf`:
```
invalid job type: convert/pdf

Did you mean: convert/markdown/pdf

Available types:
  - pdf/extract
  - pdf/extract/ocr
  - convert/markdown/pdf
  ...
```

Fixes #125