### PR TITLE
Feat: Return ENOENT exit code when input file doesn't exist (fixes #127)

### DIFF
--- a/cmd/bsubio/main.go
+++ b/cmd/bsubio/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -10,9 +11,22 @@ import (
 
 var version = "0.1.0"
 
+type ExitError struct {
+	Message string
+	Code    int
+}
+
+func (e *ExitError) Error() string {
+	return e.Message
+}
+
 func main() {
 	if err := run(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		var exitErr *ExitError
+		if errors.As(err, &exitErr) {
+			os.Exit(exitErr.Code)
+		}
 		os.Exit(1)
 	}
 }

--- a/cmd/bsubio/submit.go
+++ b/cmd/bsubio/submit.go
@@ -153,7 +153,10 @@ func runSubmit(args []string) error {
 	for _, inputFile := range inputFiles {
 		if _, err := os.Stat(inputFile); err != nil {
 			if os.IsNotExist(err) {
-				return fmt.Errorf("input file not found: %s", inputFile)
+				return &ExitError{
+					Message: fmt.Sprintf("input file not found: %s", inputFile),
+					Code:    2,
+				}
 			}
 			return fmt.Errorf("failed to access input file: %w", err)
 		}


### PR DESCRIPTION
## Summary
Add proper exit code 2 (ENOENT) when input files don't exist, allowing shell scripts to distinguish file-not-found errors from other error types.

## Changes
- Add `ExitError` type with `Message` and `Code` fields
- Update `main()` to check for `ExitError` and use its exit code
- Update submit command to return `ExitError` with code 2 for missing files

## Example
```bash
$ bsubio submit pdf/extract nonexistent.pdf
Error: input file not found: nonexistent.pdf
$ echo $?
2
```

## Test Plan
- Run `make check` - passes
- Run `make` - builds successfully
- Exit code properly returns 2 for missing files
- Other errors still return exit code 1

Fixes #127