### PR TITLE
Feat: Allow cancel command to accept multiple job IDs (fixes #129)

### DIFF
--- a/cmd/bsubio/cancel.go
+++ b/cmd/bsubio/cancel.go
@@ -68,17 +68,20 @@ func runCancel(args []string) error {
 
 		jobs := *resp.JSON200.Data.Jobs
 		canceledCount := 0
+		failedCount := 0
 
 		for _, job := range jobs {
 			if job.Status != nil && (*job.Status == "pending" || *job.Status == "claimed") {
 				cancelResp, err := client.CancelJobWithResponse(ctx, *job.Id)
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "Failed to cancel job %s: %v\n", *job.Id, err)
+					failedCount++
 					continue
 				}
 
 				if cancelResp.StatusCode() != 200 {
 					fmt.Fprintf(os.Stderr, "Failed to cancel job %s: HTTP %d\n", *job.Id, cancelResp.StatusCode())
+					failedCount++
 					continue
 				}
 
@@ -87,7 +90,11 @@ func runCancel(args []string) error {
 			}
 		}
 
-		fmt.Fprintf(os.Stderr, "Canceled %d job(s)\n", canceledCount)
+		fmt.Fprintf(os.Stderr, "Canceled %d job(s), failed %d\n", canceledCount, failedCount)
+
+		if failedCount > 0 {
+			return fmt.Errorf("failed to cancel %d job(s)", failedCount)
+		}
 	} else {
 		// Cancel specified jobs
 		canceledCount := 0
@@ -118,7 +125,7 @@ func runCancel(args []string) error {
 			canceledCount++
 		}
 
-		if len(jobIDs) > 1 {
+		if canceledCount+failedCount > 1 {
 			fmt.Fprintf(os.Stderr, "Canceled %d job(s), failed %d\n", canceledCount, failedCount)
 		}
 


### PR DESCRIPTION
## Summary
Update cancel command to accept multiple job IDs in a single invocation, allowing bulk cancellation.

## Changes
- Update usage to show `jobid...` (multiple job IDs supported)
- Change `jobID` variable to `jobIDs` slice
- Loop through all provided job IDs
- Track canceled and failed counts
- Print summary when multiple jobs specified
- Return error if any jobs failed to cancel
- Continue processing remaining jobs even if one fails

## Examples
```bash
# Cancel single job (still works)
bsubio cancel job1

# Cancel multiple jobs
bsubio cancel job1 job2 job3

# Cancel all jobs
bsubio cancel -a
```

## Output Example
```
Canceled job: job1
Failed to cancel job job2: HTTP 404
Canceled job: job3
Canceled 2 job(s), failed 1
Error: failed to cancel 1 job(s)
```

Fixes #129