### PR TITLE
Fix: Improve error messages for cancelled/failed jobs (fixes #131)

### DIFF
--- a/cmd/bsubio/cat.go
+++ b/cmd/bsubio/cat.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/google/uuid"
@@ -98,7 +100,19 @@ func runCat(args []string) error {
 	}()
 
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("failed to get job output: HTTP %d", resp.StatusCode)
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("failed to get job output: HTTP %d", resp.StatusCode)
+		}
+
+		var errorResp struct {
+			Error string `json:"error"`
+		}
+		if err := json.Unmarshal(body, &errorResp); err == nil && errorResp.Error != "" {
+			return fmt.Errorf("failed to get job output: %s", errorResp.Error)
+		}
+
+		return fmt.Errorf("failed to get job output: HTTP %d: %s", resp.StatusCode, string(body))
 	}
 
 	// Write output to stdout

--- a/cmd/bsubio/submit.go
+++ b/cmd/bsubio/submit.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -214,6 +216,23 @@ func runSubmit(args []string) error {
 			outputResp, err := client.GetJobOutput(ctx, jobID)
 			if err != nil {
 				return fmt.Errorf("failed to get job output for %s: %w", jobID.String(), err)
+			}
+
+			if outputResp.StatusCode != 200 {
+				body, err := io.ReadAll(outputResp.Body)
+				_ = outputResp.Body.Close()
+				if err != nil {
+					return fmt.Errorf("failed to get job output for %s: HTTP %d", jobID.String(), outputResp.StatusCode)
+				}
+
+				var errorResp struct {
+					Error string `json:"error"`
+				}
+				if err := json.Unmarshal(body, &errorResp); err == nil && errorResp.Error != "" {
+					return fmt.Errorf("failed to get job output for %s: %s", jobID.String(), errorResp.Error)
+				}
+
+				return fmt.Errorf("failed to get job output for %s: HTTP %d: %s", jobID.String(), outputResp.StatusCode, string(body))
 			}
 
 			// Write output to file or stdout


### PR DESCRIPTION
## Summary
Parse server response body to extract actual error messages instead of showing generic HTTP status codes. Provides clearer feedback when jobs are cancelled, failed, or otherwise unavailable.

## Changes
- Add JSON error response parsing in `cat` command
- Add JSON error response parsing in `submit` command  
- Show actual error message from server when available
- Fall back to showing response body if JSON parsing fails
- Import `encoding/json` and `io` packages

## Example

### Before
```
$ bsubio cat <cancelled-job-id>
Error: failed to get job output: HTTP 400
```

### After
```
$ bsubio cat <cancelled-job-id>
Error: failed to get job output: job was cancelled
```

## Implementation
When receiving non-200 status from `GetJobOutput`:
1. Read response body
2. Try to parse as JSON with `{"error": "message"}` format
3. If successful, show the error message
4. Otherwise, show HTTP status + raw response body

Fixes #131