### PR TITLE
Fix: Remove duplicate CI runs by removing pull_request trigger (fixes #133)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,6 @@ on:
       - '**'
     tags-ignore:
       - '**'
-  pull_request:
   workflow_dispatch:
     inputs:
       debug:


### PR DESCRIPTION
## Summary
Remove `pull_request` trigger from build workflow to prevent duplicate CI runs. CI was running twice for PR pushes (once for push, once for pull_request event).

## Problem
When pushing to a PR branch:
1. Push event triggers build workflow ✅
2. Pull request event also triggers build workflow ❌ (duplicate)

Result: Same commit tested twice, wasting CI resources

## Solution
Remove `pull_request` trigger, keep only `push` trigger for all branches.

## Behavior After Fix
- **Branch push**: CI runs once ✅
- **PR creation**: No additional run (already ran on push) ✅
- **PR update**: No additional run (already ran on push) ✅
- **Merge to main**: CI runs once, creates release if feat/fix commits ✅
- **Manual trigger**: Still works via workflow_dispatch ✅

## Changes
- Remove `pull_request:` from workflow triggers
- Keep `push: branches: ['**']` for all branches
- Keep `workflow_dispatch:` for manual runs
- Release steps remain conditional on `github.ref == 'refs/heads/main'`

Fixes #133