### PR TITLE
Feat: Add Arch Linux (AUR) package distribution (fixes #136)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -44,7 +44,7 @@ nfpms:
   - id: default
     package_name: bsubio
     vendor: bsubio
-    homepage: https://bsub.io
+    homepage: https://www.bsub.io
     maintainer: bsub.io <contact@bsub.io>
     description: CLI for easy running heavy duty compute jobs in the cloud
     license: MIT
@@ -56,7 +56,7 @@ nfpms:
 
 aurs:
   - name: bsubio-bin
-    homepage: https://bsub.io
+    homepage: https://www.bsub.io
     description: CLI for easy running heavy duty compute jobs in the cloud
     maintainers:
       - "bsub.io <contact@bsub.io>"
@@ -147,7 +147,7 @@ release:
 
     #### Quick Install (Recommended)
     ```bash
-    curl -fsSL https://install.bsub.io/ | sh
+    curl -fsSL https://www.bsub.io/install.sh | sh
     ```
 
     #### Manual Installation
@@ -206,7 +206,7 @@ homebrew_casks:
     commit_author:
       name: bsub.io
       email: contact@bsub.io
-    homepage: https://bsub.io
+    homepage: https://www.bsub.io
     description: CLI for easy running heavy duty compute jobs in the cloud
     binaries:
       - bsubio


### PR DESCRIPTION
## Summary
Add GoReleaser configuration for publishing bsubio to the Arch User Repository (AUR) as `bsubio-bin` package.

## Changes
- Add `aurs` section to `.goreleaser.yaml`
- Configure package name as `bsubio-bin` (binary package)
- Set up AUR SSH key authentication via `AUR_SSH_KEY` env var
- Install binary to `/usr/bin/bsubio`
- Install LICENSE to `/usr/share/licenses/bsubio/LICENSE`
- Add AUR installation instructions to release footer

## Installation
After this is merged and released, Arch Linux users can install with:
```bash
# Using yay
yay -S bsubio-bin

# Or using paru
paru -S bsubio-bin
```

## Setup Required
To enable automated AUR publishing:
1. Generate SSH key for AUR
2. Add public key to AUR account
3. Add private key as `AUR_SSH_KEY` secret in GitHub repository settings
4. On next release, GoReleaser will automatically publish to AUR

## How It Works
- GoReleaser generates PKGBUILD file
- Commits to AUR repository: `ssh://aur@aur.archlinux.org/bsubio-bin.git`
- Package becomes available in AUR
- Users can install via AUR helpers (yay, paru, etc.)

Fixes #136