### PR TITLE
Feat: Enable Chocolatey package distribution (fixes #139)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -162,37 +162,37 @@ release:
     - [Documentation](https://docs.bsub.io)
   name_template: "{{.Tag}}"
  
-#chocolateys:
-#  - name: bsubio
-#    ids:
-#      - default
-#    title: bsubio CLI
-#    authors: bsubio
-#    project_url: https://bsub.io
-#    url_template: "https://github.com/bsubio/cli/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
-#    icon_url: https://bsub.io/favicon.ico
-#    copyright: 2025 bsubio
-#    license_url: https://github.com/bsubio/cli/blob/main/LICENSE
-#    require_license_acceptance: false
-#    project_source_url: https://github.com/bsubio/cli
-#    docs_url: https://app.bsub.io/static/docs/
-#    bug_tracker_url: https://github.com/bsubio/cli/issues
-#    tags: "cli batch-jobs job-scheduler cloud devops"
-#    summary: CLI for easy running heavy duty compute jobs in the cloud
-#    description: |
-#      bsubio CLI is a command-line tool for running heavy duty batch compute jobs and workflows on the bsubio cloud platform.
-#
-#      Features:
-#      - Submit and manage CPU/GPU batch jobs 
-#      - Monitor job status and logs
-#      - Manage job types and configurations
-#      - Upload and manage job artifacts
-#
-#      For more information, visit https://www.bsub.io
-#    release_notes: "https://github.com/bsubio/cli/releases/tag/{{ .Tag }}"
-#    api_key: "{{ .Env.CHOCOLATEY_API_KEY }}"
-#    source_repo: "https://push.chocolatey.org/"
-#    skip_publish: false
+chocolateys:
+  - name: bsubio
+    ids:
+      - default
+    title: bsubio CLI
+    authors: bsubio
+    project_url: https://bsub.io
+    url_template: "https://github.com/bsubio/cli/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    icon_url: https://bsub.io/favicon.ico
+    copyright: 2025 bsubio
+    license_url: https://github.com/bsubio/cli/blob/main/LICENSE
+    require_license_acceptance: false
+    project_source_url: https://github.com/bsubio/cli
+    docs_url: https://app.bsub.io/static/docs/
+    bug_tracker_url: https://github.com/bsubio/cli/issues
+    tags: "cli batch-jobs job-scheduler cloud devops"
+    summary: CLI for easy running heavy duty compute jobs in the cloud
+    description: |
+      bsubio CLI is a command-line tool for running heavy duty batch compute jobs and workflows on the bsubio cloud platform.
+
+      Features:
+      - Submit and manage CPU/GPU batch jobs
+      - Monitor job status and logs
+      - Manage job types and configurations
+      - Upload and manage job artifacts
+
+      For more information, visit https://www.bsub.io
+    release_notes: "https://github.com/bsubio/cli/releases/tag/{{ .Tag }}"
+    api_key: "{{ .Env.CHOCOLATEY_API_KEY }}"
+    source_repo: "https://push.chocolatey.org/"
+    skip_publish: false
 
 homebrew_casks:
   - name: bsubio


### PR DESCRIPTION
## Summary
Uncomment Chocolatey configuration in .goreleaser.yaml to enable publishing bsubio to the Chocolatey package repository for Windows users.

## Changes
- Uncomment `chocolateys` section in `.goreleaser.yaml`
- Fix trailing whitespace in description

## Installation After Release
Windows users can install with:
```powershell
choco install bsubio
```

## Package Details
- **Package name**: bsubio
- **Title**: bsubio CLI
- **Tags**: cli, batch-jobs, job-scheduler, cloud, devops
- **Repository**: https://community.chocolatey.org/packages/bsubio

## Setup Required
To enable automated Chocolatey publishing:
1. Create account at https://community.chocolatey.org/
2. Get API key from account settings
3. Add `CHOCOLATEY_API_KEY` secret to GitHub repository settings
4. On next release, GoReleaser will automatically publish to Chocolatey

## How It Works
- GoReleaser generates .nupkg package
- Publishes to https://push.chocolatey.org/
- Package becomes available in Chocolatey repository
- Users can install via `choco install bsubio`

Fixes #139