### PR TITLE
Feat: Add winget package distribution (fixes #137)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -204,8 +204,8 @@ winget:
     publisher: bsubio
     short_description: CLI for easy running heavy duty compute jobs in the cloud
     license: MIT
-    homepage: https://bsub.io
-    publisher_url: https://bsub.io
+    homepage: https://www.bsub.io
+    publisher_url: https://www.bsub.io
     publisher_support_url: https://github.com/bsubio/cli/issues
     package_identifier: bsubio.bsubio
     repository:


### PR DESCRIPTION
## Summary
Add GoReleaser configuration for publishing bsubio to Windows Package Manager (winget). GoReleaser will automatically create pull requests to the microsoft/winget-pkgs repository on each release.

## Changes
- Add `winget` section to `.goreleaser.yaml`
- Configure package identifier as `bsubio.bsubio`
- Set up automated PR creation to `microsoft/winget-pkgs`
- Add winget installation instructions to release footer

## Installation After Release
Windows users can install with:
```powershell
winget install bsubio.bsubio
```

## How It Works
1. On release, GoReleaser generates winget package manifest
2. Creates PR to https://github.com/microsoft/winget-pkgs
3. Once PR is reviewed and merged by Microsoft, package becomes available
4. Users can install via `winget install bsubio.bsubio`

## Setup Required
To enable automated winget publishing:
1. Create GitHub Personal Access Token with `public_repo` scope
2. Add `WINGET_GITHUB_TOKEN` secret to GitHub repository settings
3. On next release, GoReleaser will create PR to winget-pkgs

## Package Details
- **Package identifier**: bsubio.bsubio
- **Publisher**: bsubio
- **License**: MIT
- **Tags**: cli, batch-jobs, job-scheduler, cloud, devops

Fixes #137