### PR TITLE
Fix: Add Docker CLI to CI container for Docker builds (fixes #145)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user root -v /var/run/docker.sock:/var/run/docker.sock
     outputs:
       should_release: ${{ steps.next_version.outputs.should_release }}
       new_version: ${{ steps.next_version.outputs.new_version }}

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,6 +1,6 @@
 FROM ubuntu:24.04
 
-# Install system dependencies
+# Install system dependencies including Docker CLI
 RUN apt-get update && apt-get install -y \
     gnupg \
     ca-certificates \
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
     curl \
     git \
     build-essential \
+    docker.io \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Go 1.25.4


### PR DESCRIPTION
## Summary
Install Docker CLI in CI container and mount Docker socket to enable Docker builds in GoReleaser while maintaining the custom CI environment.

## Problem
Docker builds were failing because the CI container didn't have Docker available:
```
exec: "docker": executable file not found in $PATH
```

## Solution
Instead of removing the custom CI container, we:
1. Add `docker.io` package to Dockerfile.ci
2. Mount Docker socket from host: `-v /var/run/docker.sock:/var/run/docker.sock`
3. Run container as root to access the socket

## How It Works
- Docker CLI installed in container
- Docker socket mounted from GitHub Actions runner
- Container uses host's Docker daemon (no Docker-in-Docker)
- All existing CI tools preserved (Chocolatey, Mono, .NET, golangci-lint)

## Benefits
- ✅ Docker builds work in CI
- ✅ Keep custom CI environment
- ✅ No Docker-in-Docker complexity
- ✅ Standard practice for containerized builds

## Testing
After merging and rebuilding the CI container, the next release will successfully build and push Docker images to ghcr.io.

Fixes #145