### PR TITLE
Fix: Remove buildx to fix --load flag error (fixes #149)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -244,7 +244,6 @@ dockers:
   - image_templates:
       - "ghcr.io/bsubio/cli:{{ .Tag }}-amd64"
     dockerfile: Dockerfile
-    use: buildx
     goos: linux
     goarch: amd64
     build_flag_templates:
@@ -263,7 +262,6 @@ dockers:
   - image_templates:
       - "ghcr.io/bsubio/cli:{{ .Tag }}-arm64"
     dockerfile: Dockerfile
-    use: buildx
     goos: linux
     goarch: arm64
     build_flag_templates:


### PR DESCRIPTION
## Summary
Remove `use: buildx` from Docker configuration to fix the `--load` flag error that occurs with multi-platform builds.

## Problem
When using buildx with multi-platform builds, GoReleaser tries to use the `--load` flag which is incompatible:

```
docker build failed: failed to build ghcr.io/bsubio/cli:v0.15.0-arm64: 
exit status 125: unknown flag: --load
```

The `--load` flag only works for single-platform builds that are loaded into the local Docker daemon. Multi-platform builds must be pushed directly to a registry.

## Solution
Remove `use: buildx` and let GoReleaser build each architecture separately using standard Docker build. Each architecture is built individually, then `docker_manifests` combines them into multi-arch manifests.

## How It Works Now
1. Build `linux/amd64` image separately with standard Docker
2. Build `linux/arm64` image separately with standard Docker
3. Push both images to registry
4. Create `docker_manifests` to combine both into multi-arch images
5. Users pull multi-arch images that automatically select the right architecture

## Result
- ✅ Multi-arch support maintained (amd64 + arm64)
- ✅ No --load flag conflicts
- ✅ Images pushed directly to registry
- ✅ Docker manifests work correctly

## Technical Details
- Without `use: buildx`, GoReleaser uses standard `docker build` for each architecture
- The `goarch` field ensures the correct Go binary is used in each image
- `docker_manifests` section creates the multi-arch manifests after individual builds

Fixes #149