### PR TITLE
Fix: Temporarily disable winget publishing (fixes #158)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -232,7 +232,9 @@ winget:
       name: bsub.io
       email: contact@bsub.io
     url_template: "https://github.com/bsubio/cli/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
-    skip_upload: false
+    # Temporarily disabled - winget requires manual first submission to microsoft/winget-pkgs
+    # After first manual PR is merged, change this to: skip_upload: '{{ not (env "WINGET_GITHUB_TOKEN") }}'
+    skip_upload: true
     release_notes: "{{ .Changelog }}"
     tags:
       - cli


### PR DESCRIPTION
## Summary
Temporarily disables winget publishing until manual first submission is completed.

## Problem
Winget requires a manual first submission to the microsoft/winget-pkgs repository. GoReleaser was attempting to UPDATE a non-existent manifest, resulting in 404 errors.

## Solution
Set `skip_upload: true` for winget with clear comments explaining:
- Why it's disabled
- That first submission must be manual
- How to re-enable after first submission is merged

## After First Manual Submission
Change the skip condition to:
```yaml
skip_upload: '{{ not (env "WINGET_GITHUB_TOKEN") }}'
```

Fixes #158